### PR TITLE
Add boolean `instert_sic` that enables sea ice concentration insertion as done in CICE4

### DIFF
--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -84,7 +84,7 @@
           restart, restart_ext, restart_coszen, use_restart_time, &
           runtype, restart_file, restart_dir, runid, pointer_file, &
           restart_format, restart_rearranger, restart_iotasks, restart_root, &
-          restart_stride, restart_deflate, restart_chunksize
+          restart_stride, restart_deflate, restart_chunksize, insert_sic
       use ice_history_shared, only: &
           history_precision, hist_avg, history_format, history_file, incond_file, &
           history_dir, incond_dir, version_name, history_rearranger, &
@@ -288,7 +288,7 @@
         fyear_init,     ycycle,          wave_spec_file,restart_coszen, &
         atm_data_dir,   ocn_data_dir,    bgc_data_dir,                  &
         atm_data_format, ocn_data_format, rotate_wind,                  &
-        oceanmixed_file, atm_data_version
+        oceanmixed_file, atm_data_version, insert_sic
 
       !-----------------------------------------------------------------
       ! default values
@@ -558,6 +558,7 @@
       restore_ocn     = .false.   ! restore sst if true
       trestore        = 90        ! restoring timescale, days (0 instantaneous)
       restore_ice     = .false.   ! restore ice state on grid edges if true
+      insert_sic      = .false.   ! if true, on restart update concentration from a file
       debug_forcing   = .false.   ! true writes diagnostics for input forcing
 
       latpnt(1) =  90._dbl_kind   ! latitude of diagnostic point 1 (deg)
@@ -1145,6 +1146,7 @@
       call broadcast_scalar(restore_ocn,          master_task)
       call broadcast_scalar(trestore,             master_task)
       call broadcast_scalar(restore_ice,          master_task)
+      call broadcast_scalar(insert_sic,           master_task)
       call broadcast_scalar(debug_forcing,        master_task)
       call broadcast_array (latpnt(1:2),          master_task)
       call broadcast_array (lonpnt(1:2),          master_task)
@@ -2626,6 +2628,7 @@
          write(nu_diag,1011) ' restore_ice      = ', restore_ice
          if (restore_ice .or. restore_ocn) &
          write(nu_diag,1021) ' trestore         = ', trestore
+         write(nu_diag,1011) ' insert_sic       = ', insert_sic
 
          write(nu_diag,*) ' '
          write(nu_diag,'(a31,2f8.2)') 'Diagnostic point 1: lat, lon =', &

--- a/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
@@ -25,12 +25,15 @@
           field_loc_Eface, field_loc_Nface, &
           field_type_scalar, field_type_vector
       use ice_restart_shared, only: restart_dir, pointer_file, &
-          runid, use_restart_time, lenstr, restart_coszen
+          runid, use_restart_time, lenstr, restart_coszen, &
+          insert_sic
       use ice_restart
       use ice_exit, only: abort_ice
       use ice_fileunits, only: nu_diag, nu_rst_pointer, nu_restart, nu_dump
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
       use icepack_intfc, only: icepack_aggregate
+      use icepack_intfc, only: icepack_query_parameters
+      use icepack_intfc, only: icepack_query_tracer_flags
       use icepack_intfc, only: icepack_query_tracer_indices, icepack_query_tracer_sizes
 
       implicit none
@@ -298,6 +301,11 @@
           aice0, aicen, vicen, vsnon, trcrn, aice_init, uvel, vvel, &
           uvelE, vvelE, uvelN, vvelN, &
           trcr_base, nt_strata, n_trcr_strata
+      use icepack_itd, only: cleanup_itd  !for insert_sic
+      use ice_arrays_column, only: first_ice, hin_max
+      use ice_flux, only: fpond, fresh, fsalt, fhocn
+      use ice_flux_bgc, only: faero_ocn, fiso_ocn, flux_bio
+      use ice_calendar, only: dt
 
       character (*), optional :: ice_ic
 
@@ -309,7 +317,8 @@
          nt_Tsfc, nt_sice, nt_qice, nt_qsno
 
       logical (kind=log_kind) :: &
-         diag
+         diag, &
+         tr_aero, tr_pond_topo
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
          work1
@@ -325,6 +334,7 @@
 
       call icepack_query_tracer_indices(nt_Tsfc_out=nt_Tsfc, nt_sice_out=nt_sice, &
            nt_qice_out=nt_qice, nt_qsno_out=nt_qsno)
+      call icepack_query_tracer_flags(tr_aero_out=tr_aero, tr_pond_topo_out=tr_pond_topo)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
@@ -717,6 +727,67 @@
          npt = npt - istep0
       endif
 
+      !-----------------------------------------------------------------
+      ! update concentration from a file
+      !-----------------------------------------------------------------
+      if (insert_sic) then
+
+         if (my_task == master_task) &
+              write(nu_diag,*) "Inserting sic"
+
+         call direct_insert_sic
+
+         !-----------------------------------------------------------------
+         ! Ensure ice is binned in correct categories
+         !-----------------------------------------------------------------
+         do iblk = 1, nblocks
+            do j = 1, ny_block
+            do i = 1, nx_block
+               if (tmask(i,j,iblk)) then
+
+                  call cleanup_itd(dt,    hin_max,             &
+                       aicen(i,j,:,iblk), trcrn(i,j,:,:,iblk), &
+                       vicen(i,j,:,iblk), vsnon(i,j,:,  iblk), &
+                       aice0(i,j,  iblk),  aice(i,j,    iblk), &
+                       tr_aero,           tr_pond_topo,        &
+                       first_ice(i,j,:,iblk),                  &
+                       trcr_depend,       trcr_base,           &
+                       n_trcr_strata,     nt_strata,           &
+                       fpond     =     fpond(i,j,  iblk),      &
+                       fresh     =     fresh(i,j,  iblk),      &
+                       fsalt     =     fsalt(i,j,  iblk),      &
+                       fhocn     =     fhocn(i,j,  iblk),      &
+                       faero_ocn = faero_ocn(i,j,:,iblk),      &
+                       fiso_ocn  =  fiso_ocn(i,j,:,iblk),      &
+                       flux_bio  =  flux_bio(i,j,:,iblk),      &
+                       Tf        =        Tf(i,j,  iblk),      &
+                       limit_aice_in = .true. )
+
+                  call icepack_aggregate( &
+                                   aicen = aicen(i,j,:,iblk),     &
+                                   trcrn = trcrn(i,j,:,:,iblk),   &
+                                   vicen = vicen(i,j,:,iblk),     &
+                                   vsnon = vsnon(i,j,:,iblk),     &
+                                   aice  = aice (i,j,  iblk),     &
+                                   trcr  = trcr (i,j,:,iblk),     &
+                                   vice  = vice (i,j,  iblk),     &
+                                   vsno  = vsno (i,j,  iblk),     &
+                                   aice0 = aice0(i,j,  iblk),     &
+                                   trcr_depend   = trcr_depend,   &
+                                   trcr_base     = trcr_base,     &
+                                   n_trcr_strata = n_trcr_strata, &
+                                   nt_strata     = nt_strata,     &
+                                   Tf            = Tf(i,j,iblk))
+
+                  aice_init(i,j,iblk) = aice(i,j,iblk)
+
+               endif  ! tmask
+            enddo     ! i
+            enddo     ! j
+         enddo        ! iblk
+
+      endif !insert_sic
+
       end subroutine restartfile
 
 !=======================================================================
@@ -1091,6 +1162,309 @@
       endif
 
       end subroutine restartfile_v4
+
+!=======================================================================
+!  Direct insertion of ice concentration read from file.
+!
+!  Posey, et. al. 2015: Improving Arctic sea ice edge forecasts by 
+!  assimilating high horizontal resolution sea ice concentration
+!  data into the US Navy's ice forecast systems.
+!  The Cryosphere.  doi:10.5194/tc-9-1735-2015
+!
+!  Alan J. Wallcraft, COAPS/FSU, Nov 2024
+
+      subroutine direct_insert_sic
+        
+        use ice_blocks, only: nghost, nx_block, ny_block
+        use ice_domain, only: nblocks
+        use ice_domain_size, only: nilyr, nslyr, ncat, max_blocks
+        use ice_grid, only: tmask
+        use ice_communicate, only: my_task, master_task
+        use ice_constants, only: c0, c1, c4, p5, p2, p1, p01, p001, &
+             field_loc_center, field_loc_NEcorner, &
+             field_type_scalar, field_type_vector
+        use ice_fileunits, only: nu_diag
+        use ice_flux, only:  &
+             Tair, Tf, salinz, Tmltz, sst,                  &
+             stressp_1, stressp_2, stressp_3, stressp_4,    &
+             stressm_1, stressm_2, stressm_3, stressm_4,    &
+             stress12_1, stress12_2, stress12_3, stress12_4
+        use ice_state, only:  &
+             aice, aicen, vicen, vsnon, trcrn
+        use ice_read_write, only: ice_check_nc, ice_read_nc
+        use ice_arrays_column, only: hin_max
+        ! use icepack_mushy_physics, only: enthalpy_mush 
+        use icepack_intfc, only: icepack_init_trcr
+#ifdef USE_NETCDF
+        use netcdf
+#endif   
+
+        ! --- local variables
+        real(kind=dbl_kind) :: &
+             q     ,    & ! scale factor 
+             aice_m,    & ! model aice
+             aice_o,    & ! observation aice
+             aice_t,    & ! target aice
+             aice_i,    & ! insert ice
+             slope,     & ! used to compute surf Temp
+             Ti,        & ! target surface temperature
+             edge_om,   & ! nominal ice edge zone
+             diff_om,   & ! allowed model vs obs difference
+             hin_om,    & ! new ice thickness
+             aicen_old, & ! old value of aice to check when adding ice
+             vsnon_old, & ! old value of snow volume to check when adding ice
+             Tsfc         ! surface temp.
+        integer (kind=int_kind) :: ncid, status
+        integer (kind=int_kind) :: &
+             i, j, k, n, iblk  ! counting  indices
+        logical (kind=log_kind) :: &
+             diag  ! diagnostic output
+        real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
+             work1
+        real (kind=dbl_kind), dimension(nilyr) :: &
+             qin             ! ice enthalpy (J/m3)
+        real (kind=dbl_kind), dimension(nslyr) :: &
+             qsn             ! snow enthalpy (J/m3)
+
+        ! parameters from icepack
+        real (kind=dbl_kind) :: & 
+             puny, Tffresh, Tsmelt, Lfresh, cp_ice, cp_ocn, &
+             rhos, rhoi
+        integer (kind=int_kind) :: &
+             nt_Tsfc, nt_sice, nt_qice, nt_qsno, &
+             ktherm
+        character(len=*), parameter :: subname = '(direct_insert_sic)'
+        
+        diag = .true.
+        
+        ! get parameters from icepack
+        call icepack_query_parameters( &
+             puny_out=puny,            &
+             Tffresh_out=Tffresh,      &
+             Tsmelt_out=Tsmelt,        &
+             Lfresh_out=Lfresh,        &
+             cp_ice_out=cp_ice,        &
+             cp_ocn_out=cp_ocn,        &
+             rhos_out=rhos,            &
+             rhoi_out=rhoi,            &
+             ktherm_out=ktherm         )
+        
+        call icepack_query_tracer_indices( &
+             nt_Tsfc_out=nt_Tsfc,          &
+             nt_sice_out=nt_sice,          &
+             nt_qice_out=nt_qice,          &
+             nt_qsno_out=nt_qsno           )
+
+        call icepack_warnings_flush(nu_diag)
+        if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
+             file=__FILE__, line=__LINE__)
+
+#ifdef USE_NETCDF
+        if (my_task == master_task) then
+           write(nu_diag,*) "direct_insert_sic"
+           status = nf90_open(trim(restart_dir)//'/sic.nc', nf90_nowrite, ncid)
+           call ice_check_nc(status, subname//' ERROR: open '//trim(restart_dir)//'/sic.nc', file=__FILE__, line=__LINE__)
+        endif !master_task
+        call ice_read_nc(ncid,1,'sic',work1, diag, &
+                         field_loc=field_loc_center, &
+                         field_type=field_type_scalar)  
+        if (my_task == master_task) then
+           ! ncid is only valid on master
+           status = nf90_close(ncid)
+           call ice_check_nc(status, subname//' ERROR: closing', file=__FILE__, line=__LINE__)
+        endif 
+#else      
+        call abort_ice(subname//' ERROR: USE_NETCDF cpp not defined', &
+            file=__FILE__, line=__LINE__)
+#endif 
+
+        edge_om = p2  ! nominal ice edge zone
+        diff_om = p1  ! allowed model vs obs difference
+        hin_om  = hin_max(1)*0.9_dbl_kind  !new ice thickness
+        
+        do iblk = 1, nblocks
+           do j = 1, ny_block
+           do i = 1, nx_block
+                 
+              aice_o = work1(i,j,iblk) ! obs.  ice concentration
+              aice_m = aice(i,j,iblk)  ! model ice concentration
+
+              if     (.not.tmask(i,j,iblk)) then
+                 ! land - do nothing
+              elseif (aice_o.gt.p01 .and. &
+                   abs(aice_o-aice_m).le.p01) then
+                 ! model and obs are very close - do nothing
+              elseif (min(aice_o,aice_m).ge.edge_om .and. &
+                   abs(aice_o-aice_m).le.diff_om) then
+                 ! model and obs are close enough - do nothing
+              elseif (aice_o.eq.aice_m) then
+              elseif (aice_o.lt.aice_m) then
+                 if (aice_o.lt.p01)then
+                    ! --- remove all ice ---
+                    ! warm sst so the ice won't grow immediately
+                    sst(i,j,iblk) = sst(i,j,iblk) + p2
+                    do n=1,ncat
+                       aicen(i,j,n,iblk) = c0  
+                       vicen(i,j,n,iblk) = c0
+                       vsnon(i,j,n,iblk) = c0
+                       call icepack_init_trcr( &
+                            Tair     =   Tair(i,j,  iblk), &
+                            Tf       =     Tf(i,j,  iblk), &
+                            Sprofile = salinz(i,j,:,iblk), &
+                            Tprofile =  Tmltz(i,j,:,iblk), &
+                            Tsfc     = Tsfc,               &
+                            qin      = qin(:),             &
+                            qsn      = qsn(:)              )
+                       ! surface temperature
+                       trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                       ! ice enthalpy, salinity
+                       do k = 1, nilyr
+                          trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                          trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                       enddo  ! nilyr
+                       ! snow enthalpy
+                       do k = 1, nslyr
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                       enddo  ! nslyr
+                    enddo !n
+                    stressp_1 (i,j,iblk) = c0
+                    stressp_2 (i,j,iblk) = c0
+                    stressp_3 (i,j,iblk) = c0
+                    stressp_4 (i,j,iblk) = c0
+                    stressm_1 (i,j,iblk) = c0
+                    stressm_2 (i,j,iblk) = c0
+                    stressm_3 (i,j,iblk) = c0
+                    stressm_4 (i,j,iblk) = c0
+                    stress12_1(i,j,iblk) = c0
+                    stress12_2(i,j,iblk) = c0
+                    stress12_3(i,j,iblk) = c0
+                    stress12_4(i,j,iblk) = c0
+                 else !aice_o.ge.p01
+                    if     (aice_o.lt.edge_om) then
+                       ! --- target ice conc. is obs.
+                       aice_t = aice_o
+                    else !aice_m-aice_o.gt.diff_om
+                       ! --- target ice conc. is obs.+diff_om
+                       aice_t = aice_o + diff_om
+                    endif
+                    ! --- reduce ice to the target concentration,
+                    !     completely exhasting ice categories in order ---
+                    aice_i = aice_m - aice_t   !>=0.0
+                    do n=1,ncat
+                       if     (aice_i.le.p001) then
+                          exit
+                       elseif (aice_i.ge.aicen(i,j,n,iblk)) then
+                          ! --- remove all of this category
+                          aice_i = aice_i - aicen(i,j,n,iblk)
+                          aicen(i,j,n,iblk) = c0  
+                          vicen(i,j,n,iblk) = c0
+                          vsnon(i,j,n,iblk) = c0
+                          call icepack_init_trcr( &
+                               Tair     =   Tair(i,j,  iblk), &
+                               Tf       =     Tf(i,j,  iblk), &
+                               Sprofile = salinz(i,j,:,iblk), &
+                               Tprofile =  Tmltz(i,j,:,iblk), &
+                               Tsfc     = Tsfc,               &
+                               qin      = qin(:),             &
+                               qsn      = qsn(:)              )
+                          ! surface temperature
+                          trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                          ! ice enthalpy, salinity
+                          do k = 1, nilyr
+                             trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                             trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                          enddo  ! nilyr
+                          ! snow enthalpy
+                          do k = 1, nslyr
+                             trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                          enddo  ! nslyr
+                       else  !aice_i.lt.aicen(i,j,n,iblk)
+                          ! --- remove part of this category
+                          q = (aicen(i,j,n,iblk) - aice_i) &
+                               /aicen(i,j,n,iblk)              !<1
+                          aice_i = c0
+                          
+                          ! reduce aicen, vicen, vsnon by q
+                          ! do not alter Tsfc since there is already 
+                          ! ice here. 
+                          aicen(i,j,n,iblk) = q*aicen(i,j,n,iblk)
+                          vicen(i,j,n,iblk) = q*vicen(i,j,n,iblk)
+                          vsnon(i,j,n,iblk) = q*vsnon(i,j,n,iblk)
+                       endif    ! aice_i.gt.p001 and aice_i.lt.aicen 
+                    enddo       ! n
+                 endif          ! aice_o.lt.p01
+              elseif (aice_o.gt.p01) then  ! .and. aice_o.gt.aicen
+                 if     (aice_m.lt.edge_om) then
+                    ! --- target ice conc. is obs.
+                    aice_t = aice_o
+                 else !aice_o-aice_m.gt.diff_om
+                    ! --- target ice conc. is obs.-diff_om
+                    aice_t = aice_o - diff_om
+                 endif
+                 q = (aice_t-aice_m)
+                 ! --- add ice to the target concentration,
+                 ! --- with all new ice in category 1 
+                 ! --- cool sst so the ice won't melt immediately
+                 sst(  i,j,  iblk) = sst(  i,j,  iblk) - q  ! 0 <= q <= 1
+                 aicen_old         = aicen(i,j,1,iblk)  ! store to check for zero ice later
+                 vsnon_old         = vsnon(i,j,1,iblk)  ! store to check for zero snow later
+                 aicen(i,j,1,iblk) = aicen(i,j,1,iblk) + q
+                 vicen(i,j,1,iblk) = vicen(i,j,1,iblk) + q*hin_om
+                 vsnon(i,j,1,iblk) = vsnon(i,j,1,iblk) + q*hin_om*p2
+             
+                 ! ------------------------------------------------------
+                 ! check for zero snow in 1st category. 
+                 ! It is possible that there was ice
+                 ! but no snow. This would skip the loop below and an 
+                 ! error in snow thermo would occur. If snow was zero 
+                 ! specify enthalpy here
+                 ! ------------------------------------------------------
+                 if (vsnon_old < puny) then
+                    do n=1,1           ! only do 1st category
+                       ! --- snow layers
+                       trcrn(i,j,nt_Tsfc,n,iblk) =   &      ! Tsfc
+                            min(Tsmelt,Tair(i,j,iblk) - Tffresh) 
+                       Ti = min(c0,trcrn(i,j,nt_Tsfc,n,iblk))
+                       do k=1,nslyr 
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = -rhos*(Lfresh - cp_ice*Ti)
+                       enddo ! k
+                    enddo ! n = 1,1
+                 endif
+
+                 ! ------------------------------------------------------
+                 ! check for zero aice in 1st category. 
+                 ! if adding to an initially zero ice, we must define
+                 ! qice, qsno, sice so thermo does not blow up.
+                 ! ------------------------------------------------------
+                 if (aicen_old < puny) then
+                    do n =1,1  ! only do 1st category
+                       call icepack_init_trcr( &
+                            Tair     =   Tair(i,j,  iblk), &
+                            Tf       =     Tf(i,j,  iblk), &
+                            Sprofile = salinz(i,j,:,iblk), &
+                            Tprofile =  Tmltz(i,j,:,iblk), &
+                            Tsfc     = Tsfc,               &
+                            qin      = qin(:),             &
+                            qsn      = qsn(:)              )
+                       ! surface temperature
+                       trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                       ! ice enthalpy, salinity
+                       do k = 1, nilyr
+                          trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                          trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                       enddo
+                       ! snow enthalpy
+                       do k = 1, nslyr
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                       enddo               ! nslyr
+                    enddo       ! n 
+                 endif          ! qice == c0
+              endif             ! aice_o vs aice_m or tmask
+           enddo                ! j
+           enddo                ! i
+        enddo                   ! iblk
+
+      end subroutine direct_insert_sic
 
 !=======================================================================
 

--- a/cicecore/shared/ice_restart_shared.F90
+++ b/cicecore/shared/ice_restart_shared.F90
@@ -9,10 +9,13 @@
       public :: lenstr
 
       logical (kind=log_kind), public :: &
-         restart    , &   ! if true, initialize using restart file instead of defaults
-         restart_ext, &   ! if true, read/write extended grid (with ghost cells)
-         restart_coszen, &   ! if true, read/write coszen
-         use_restart_time ! if true, use time written in core restart file
+         restart       , & ! if true, initialize using restart file instead of defaults
+         restart_ext   , & ! if true, read/write extended grid (with ghost cells)
+         restart_coszen, & ! if true, read/write coszen
+         use_restart_time  ! if true, use time written in core restart file
+
+      logical(kind=log_kind), public :: &
+           insert_sic      ! if true, update restart concentation from a file
 
       character (len=char_len), public :: &
          runtype           ! initial, continue, hybrid, branch


### PR DESCRIPTION
In CICE4, used in [RTOFS](https://github.com/NOAA-EMC/RTOFS_GLO/):
- We use the sea ice concentration from a data assimilation.
- The usage is turned `ON` (default: `OFF`) via a logical: `insert_sic` variable.
- See details in [ice_restart.](https://github.com/NOAA-EMC/RTOFS_GLO/blob/develop/sorc/rtofs_hycom.fd/src_2.2.99DHMTi-dist2B_relo_cice_v4.0e/source/ice_restart.F90)
- @awallcraft ported the code he wrote (and is used in CICE4) to CICE6.
- The reason for _this_ PR is for testing within:
   - [RTOFS.](https://github.com/NOAA-EMC/RTOFS_GLO/tree/develop)
   - [UFS weather model.](https://github.com/ufs-community/ufs-weather-model)
   - via @sanAkel's (this) branch- so he can make his changes (as needed) and send PRs to upstream repositories.